### PR TITLE
Update navigation bar theme

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -3,6 +3,11 @@
     <style name="Base.Theme.JugendteamSpielekartei" parent="Theme.Material3.DayNight.NoActionBar">
         <!-- Customize your light theme here. -->
         <!-- <item name="colorPrimary">@color/my_light_primary</item> -->
+
+        <!-- Navigation bar color -->
+        <item name="android:navigationBarColor">@color/white</item>
+        <!-- For API 27 and above, make navigation bar icons dark for light navigation bar -->
+        <item name="android:windowLightNavigationBar" tools:targetApi="o_mr1">true</item>
     </style>
 
     <style name="roundImage">


### PR DESCRIPTION
- Updated `themes.xml`:
    - Set `android:navigationBarColor` to `@color/white`.
    - Set `android:windowLightNavigationBar` to `true` to make navigation bar icons dark for light navigation bar (API 27+).